### PR TITLE
お気に入り機能削除システムの更新

### DIFF
--- a/frontend/src/components/CountryTabs.vue
+++ b/frontend/src/components/CountryTabs.vue
@@ -57,7 +57,6 @@ export default {
         // YoutubeAPIにより指定プレイリストの動画を取得し、それらをitemsにいれる
         axios.get('https://www.googleapis.com/youtube/v3/playlistItems', { params: that.getPlayListParams })
         .then(function (response) {
-            that.show = false;
             that.items = response.data.items;
             that.getRegionsVideos(that.regions[0]);
         })
@@ -77,6 +76,7 @@ export default {
                           }
                          )
                 .then(function (response) {
+                    that.show = false;
                     that.selectedRegionData = response.data;
                     that.compareSelectedRegionDataAndItems();
                 })

--- a/frontend/src/components/Youtube.vue
+++ b/frontend/src/components/Youtube.vue
@@ -208,9 +208,9 @@ export default {
 
         if(this.show2 == true){this.show2 = false;}  //初めて表示ボタンを押す時には.iframe-coverを外す。
     },
+    // ログインしているユーザーがお気に入りした全ての動画のvideo_idを取得し、その中に選択した動画のidがあるか調べる。
+    // あればお気に入り登録されているのでハートマークを赤色に、なければそのままにする。
     whetherAddedFavorite(){
-         // ログインしているユーザーがお気に入りした全ての動画のvideo_idを取得し、その中に選択した動画のidがあるか調べる。
-         // あればお気に入り登録されているのでハートマークを赤色に、なければそのままにする。
         let that = this;
         const url = process.env.VUE_APP_API_BASE_URL + '/users/favorites';
         axios.get(url, {withCredentials: true, headers: { 'X-Requested-With': 'XMLHttpRequest' }} )
@@ -233,13 +233,16 @@ export default {
           this.heartColor = "pink";
           this.addFavorite();
       }else{
-          this.heartIcon = "mdi-heart-outline";
-          this.heartColor = null;
-          this.removeFavorite();
+          let result = confirm('お気に入りから削除すると動画のメモも削除されますがよろしいですか？');
+          if(result){
+              this.heartIcon = "mdi-heart-outline";
+              this.heartColor = null;
+              this.removeFavorite();
+          }
       }
     },
+    // お気に入りに登録したら、ログインしているユーザーとその動画をaxios.postによりfavoritesテーブルに登録する
     addFavorite(){
-        //お気に入りに登録したら、ログインしているユーザーとその動画をaxios.postによりfavoritesテーブルに登録する
         let that = this;
         const url = process.env.VUE_APP_API_BASE_URL + '/favorite';
         let params = {
@@ -260,14 +263,16 @@ export default {
             that.snackbar = false;
         }, 2000);
     },
+    // 既にお気に入りに登録している場合、favoritesテーブルのuser_idとvideo_idの一致するデータを削除する。
     removeFavorite(){
-        //既にお気に入りに登録している場合、favoritesテーブルのuser_idとvideo_idの一致するデータを削除する。
         let that = this;
         const url = process.env.VUE_APP_API_BASE_URL + '/favorite';
         let params = {
                 user_id: this.current_user.id,
                 video_id: this.videoData.id
                 };
+
+        this.$emit('deleted-favorite-video-id', this.videoData.video_id);
 
         axios.delete( url, {params: params, withCredentials: true, headers: { 'X-Requested-With': 'XMLHttpRequest' } })
         .then(function (response) {
@@ -282,6 +287,7 @@ export default {
             that.snackbar = false;
         }, 2000);
     },
+    // propで渡ってきたcustomizedTimesを開始時間のsectionのoptionとして追加している。
     getCustomizedTimes() {
         const section = document.getElementById('start');
         for (let i = 0; i < this.customizedTimes.length; i++) {
@@ -292,6 +298,7 @@ export default {
             section.appendChild(option);
         }
     },
+    // propで渡ってきたcustomizedTimesは'XX:YY:ZZ'の文字列型だから、時間、分、秒で分けてミリ秒変換してリターンしoptionのvalueとして扱う。
     getCustomizedTimeValue(time) {
         let value = time.split(':');
         let hour = Number(value[0]);
@@ -299,6 +306,7 @@ export default {
         let second = Number(value[2]);
         return String(hour * 3600 + minite * 60 + second);
     },
+    // 新たに動画を選択したり、新たにcustomizedTimesが渡ってきた時に開始時間のsectionを空にして、optionを初期化している。
     initializeStartTimes() {
         const section = document.getElementById('start');
         if(section.firstChild != null) {

--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -38,7 +38,7 @@
                         <v-card class="grey lighten-3">
                             <div class="comment">
                                 <h2>【virtualwalkとは】</h2>
-                                <p>「virtualwalk」は私がyoutube上で「virtual walking tour」と検索している<span class="comment-bold">海外の風景動画</span>を視聴しやすくすることを目的として作成しました。</p>
+                                <p>「virtualwalk」は私がyoutube上で「virtual walking tour」と検索して観ている<span class="comment-bold">海外の風景動画</span>を視聴しやすくすることを目的として作成しました。</p>
                                 <p>上記の海外風景の動画はほとんどは外国の方が撮影した動画であるため<span class="comment-bold">日本語</span>で検索することができません。
                                 <br>かと言ってそれ以上検索で絞り込みを行おうとすると都市名（Paris）などの英字名で検索する必要があり、
                                     そのスペルを知るためにはカタカナで「パリ」とググる必要があります。<span class="comment-bold">面倒ですね。</span>

--- a/frontend/src/views/User.vue
+++ b/frontend/src/views/User.vue
@@ -124,7 +124,7 @@
                     </v-card>
                 </div>
                 <div v-for="favoriteVideo of favoriteVideos" v-bind:key="favoriteVideo.id">
-                    <v-card class="favorite-video-img">
+                    <v-card class="favorite-video-img" :id="favoriteVideo.snippet.resourceId.videoId">
                         <img :src="favoriteVideo.snippet.thumbnails.medium.url"       
                             @click="showSelectedVideo(favoriteVideo.snippet.resourceId.videoId)"
                         >
@@ -139,7 +139,7 @@
     <div class="youtube-component">
       <v-btn class="close-btn" v-show="expand" @click="expand = !expand" small>close</v-btn>
         <v-card>
-          <Youtube :video-id='videoId' :expand='expand' :customizedTimes="customizedTimes" :selectedTime="selectedTime"></Youtube>
+          <Youtube @deleted-favorite-video-id='deletedFavoriteVideoId' :video-id='videoId' :expand='expand' :customizedTimes="customizedTimes" :selectedTime="selectedTime"></Youtube>
         </v-card>
       </div>
 </v-main>
@@ -157,6 +157,7 @@ import axios from 'axios'
       return {
         customizedTimes: "",
         selectedTime: "",
+        delteFavoriteId: "",
         temporaryUserData: false,
         temporaryUserDataName: "",
         temporaryUserDataEmail: "",
@@ -197,6 +198,13 @@ import axios from 'axios'
             key: process.env.VUE_APP_YOUTUBE_API_KEY
         },
       }
+    },
+    watch: {
+        // Youtubeコンポーネントでお気に入りから動画を削除すると、$emitによって削除した動画のIDが渡され、対応する動画のimgが削除される。
+        delteFavoriteId: function() {
+            let deleteItem = document.getElementById(this.delteFavoriteId);
+            deleteItem.remove();
+        }
     },
     created(){
         let that = this;
@@ -317,6 +325,9 @@ import axios from 'axios'
         },
         selectTime(e) {
             this.selectedTime = e;
+        },
+        deletedFavoriteVideoId(e) {
+            this.delteFavoriteId = e;
         }
     },
     components: {


### PR DESCRIPTION
お気に入り機能で動画をお気に入りから外すと、同時に動画のメモも削除されるようになっているので、誤作動で削除できないようにするために、確認画面を表示するようにした。そしてお気に入りから削除後はお気に入り一覧からその動画のdomを削除できるようにした。